### PR TITLE
Add a option to choose default plugin path.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.user
 build/
-/cmake-build-debug
+/cmake-build-*
 /.idea
 /compile_commands.json
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,9 @@ add_library(${PROJECT_NAME} MODULE
     ui/SSOutboundEditor.cpp
     ui/SSOutboundEditor.hpp
     ui/SSOutboundEditor.ui
+    ui/SSSettingsWidget.ui
+    ui/SSSettingsWidget.cpp
+    ui/SSSettingsWidget.hpp
     ui/GUIInterface.hpp
     resx.qrc
     ${QVPLUGIN_INTERFACE_HEADERS}
@@ -64,15 +67,15 @@ target_link_libraries(${PROJECT_NAME}
 install(TARGETS ${PROJECT_NAME} DESTINATION share/qv2ray/plugins)
 if(BUILD_TESTING)
     add_executable(testparsess test/TestParseSS.cpp test/catch.hpp
-    common/CommonHelpers.cpp
-    common/CommonHelpers.hpp
-    core/Serializer.cpp
-    core/Serializer.hpp
-    ${QVPLUGIN_INTERFACE_HEADERS})
-    target_link_libraries(testparsess 
-    ${QV_QT_LIBNAME}::Core
-    ${QV_QT_LIBNAME}::Gui
-    ${QV_QT_LIBNAME}::Widgets
-    ${QV_QT_LIBNAME}::Network)
+        common/CommonHelpers.cpp
+        common/CommonHelpers.hpp
+        core/Serializer.cpp
+        core/Serializer.hpp
+        ${QVPLUGIN_INTERFACE_HEADERS})
+    target_link_libraries(testparsess
+        ${QV_QT_LIBNAME}::Core
+        ${QV_QT_LIBNAME}::Gui
+        ${QV_QT_LIBNAME}::Widgets
+        ${QV_QT_LIBNAME}::Network)
     add_test(NAME testparsess COMMAND $<TARGET_FILE:testparsess>)
 endif()

--- a/SSPlugin.cpp
+++ b/SSPlugin.cpp
@@ -1,6 +1,7 @@
 #include "SSPlugin.hpp"
 
 #include "core/Serializer.hpp"
+#include "core/kernel/SSInstance.hpp"
 #include "ui/GUIInterface.hpp"
 
 #include <QDateTime>
@@ -14,6 +15,6 @@ bool QvSSPlugin::InitializePlugin(const QString &, const QJsonObject &_settings)
     eventHandler = std::make_shared<SSPluginEventHandler>();
     outboundHandler = std::make_shared<SSSerializer>();
     guiInterface = new ShadowsocksPluginGUIInterface();
-    kernelInterface = std::make_shared<SSKernelInterface>();
+    kernelInterface = std::make_shared<SSKernelInterface>(this);
     return true;
 }

--- a/SSPlugin.hpp
+++ b/SSPlugin.hpp
@@ -3,7 +3,6 @@
 #include "QvPluginInterface.hpp"
 #include "core/EventHandler.hpp"
 #include "core/Serializer.hpp"
-#include "core/kernel/SSInstance.hpp"
 
 #include <QObject>
 #include <QtPlugin>
@@ -11,8 +10,7 @@
 class QLabel;
 using namespace Qv2rayPlugin;
 class QvSSPlugin
-    : public QObject
-    , Qv2rayInterface
+    : public QObject, public Qv2rayInterface
 {
     Q_INTERFACES(Qv2rayPlugin::Qv2rayInterface)
     Q_PLUGIN_METADATA(IID Qv2rayInterface_IID)

--- a/common/CommonHelpers.hpp
+++ b/common/CommonHelpers.hpp
@@ -13,14 +13,23 @@ struct ShadowSocksServerObject
     QString remarks; // Unused
     QString group;   // Unused
     int port;
-    ShadowSocksServerObject()
-    {
+
+    ShadowSocksServerObject() {
         method = "chacha20-ietf-poly1305";
         address = "0.0.0.0";
         port = 0;
     }
-    JSONSTRUCT_REGISTER(ShadowSocksServerObject, F(address, method, password, plugin, plugin_options, key, remarks, group, port))
+
+    JSONSTRUCT_REGISTER(ShadowSocksServerObject,
+                        F(address, method, password, plugin, plugin_options, key, remarks, group, port))
+};
+
+struct SSPluginSettingObject {
+    QString default_plugin_prefix;
+
+    JSONSTRUCT_REGISTER(SSPluginSettingObject, F(default_plugin_prefix))
 };
 
 QString SafeBase64Decode(QString string);
+
 QString SafeBase64Encode(const QString &string, bool trim = true);

--- a/core/kernel/SSInstance.hpp
+++ b/core/kernel/SSInstance.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "3rdparty/shadowsocks-uvw/src/SSThread.hpp"
 #include "QvPluginProcessor.hpp"
+#include "SSPlugin.hpp"
 #include "common/CommonHelpers.hpp"
 #include "utils/HttpProxy.hpp"
 
@@ -9,7 +10,7 @@ using namespace Qv2rayPlugin;
 class SSKernelInstance : public PluginKernel
 {
   public:
-    explicit SSKernelInstance(QObject *parent = nullptr);
+    explicit SSKernelInstance(QvSSPlugin *_parent) : parent(_parent) {}
     bool StartKernel() override;
     bool StopKernel() override;
     void SetConnectionSettings(const QMap<KernelOptionFlags, QVariant> &options, const QJsonObject &settings) override;
@@ -26,16 +27,21 @@ class SSKernelInstance : public PluginKernel
     ShadowSocksServerObject outbound;
     std::unique_ptr<Qv2rayPlugin::Utils::HttpProxy> httpProxy;
     std::unique_ptr<SSThread> ssrThread;
+    QvSSPlugin *parent;
 };
 
-class SSKernelInterface : public PluginKernelInterface
-{
-    std::unique_ptr<PluginKernel> CreateKernel() const
-    {
-        return std::make_unique<SSKernelInstance>();
+class SSKernelInterface : public PluginKernelInterface {
+public:
+    explicit SSKernelInterface(QvSSPlugin *_parent) : parent(_parent) {}
+
+    std::unique_ptr<PluginKernel> CreateKernel() const final {
+        return std::make_unique<SSKernelInstance>(parent);
     }
-    QList<QString> GetKernelProtocols() const
-    {
-        return { "shadowsocks-sip003" };
+
+    QList<QString> GetKernelProtocols() const final {
+        return {"shadowsocks-sip003"};
     }
+
+private:
+    QvSSPlugin *parent;
 };

--- a/ui/GUIInterface.hpp
+++ b/ui/GUIInterface.hpp
@@ -1,5 +1,6 @@
 #include "QvGUIPluginInterface.hpp"
 #include "SSOutboundEditor.hpp"
+#include "SSSettingsWidget.hpp"
 
 using namespace Qv2rayPlugin;
 
@@ -11,11 +12,11 @@ class ShadowsocksPluginGUIInterface : public Qv2rayPlugin::PluginGUIInterface
     }
     QList<PluginGuiComponentType> GetComponents() const
     {
-        return { GUI_COMPONENT_OUTBOUND_EDITOR };
+        return {GUI_COMPONENT_OUTBOUND_EDITOR, GUI_COMPONENT_SETTINGS};
     }
     std::unique_ptr<QvPluginSettingsWidget> createSettingsWidgets() const
     {
-        return {};
+        return std::make_unique<SSSettingsWidget>();
     }
     QList<typed_plugin_editor> createInboundEditors() const
     {

--- a/ui/SSSettingsWidget.cpp
+++ b/ui/SSSettingsWidget.cpp
@@ -1,0 +1,25 @@
+#include "SSSettingsWidget.hpp"
+#include <QFileDialog>
+
+void SSSettingsWidget::SetSettings(const QJsonObject &content) {
+    setting.loadJson(content);
+
+    pfxPathEdit->setText(setting.default_plugin_prefix);
+}
+
+QJsonObject SSSettingsWidget::GetSettings() {
+    return setting.toJson();
+}
+
+void SSSettingsWidget::on_pfxPathPushButton_clicked() {
+    auto filename = QFileDialog::getExistingDirectory(this, tr("Default Plugin Path"), {});
+
+    if (!filename.isEmpty()) {
+        setting.default_plugin_prefix = filename;
+        pfxPathEdit->setText(filename);
+    }
+}
+
+void SSSettingsWidget::on_pfxPathEdit_textEdited(const QString &arg1) {
+    setting.default_plugin_prefix = arg1;
+}

--- a/ui/SSSettingsWidget.hpp
+++ b/ui/SSSettingsWidget.hpp
@@ -1,0 +1,31 @@
+#ifndef SSSETTINGSWIDGET_HPP
+#define SSSETTINGSWIDGET_HPP
+
+#include "QvGUIPluginInterface.hpp"
+#include "common/CommonHelpers.hpp"
+#include "ui_SSSettingsWidget.h"
+
+class SSSettingsWidget
+        : public Qv2rayPlugin::QvPluginSettingsWidget, private Ui::SSSettingsWidget {
+Q_OBJECT
+
+public:
+    explicit SSSettingsWidget(QWidget *parent = nullptr) : QvPluginSettingsWidget(parent) {
+        setupUi(this);
+    }
+
+    void SetSettings(const QJsonObject &content) override;
+
+    QJsonObject GetSettings() override;
+
+private slots:
+
+    void on_pfxPathPushButton_clicked();
+
+    void on_pfxPathEdit_textEdited(const QString &arg1);
+
+private:
+    SSPluginSettingObject setting;
+};
+
+#endif // SSSETTINGSWIDGET_HPP

--- a/ui/SSSettingsWidget.ui
+++ b/ui/SSSettingsWidget.ui
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SSSettingsWidget</class>
+ <widget class="QWidget" name="SSSettingsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="QWidget" name="">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>30</y>
+     <width>361</width>
+     <height>82</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QLabel" name="label">
+      <property name="text">
+       <string>Default Prefix for Plugins</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLineEdit" name="pfxPathEdit"/>
+    </item>
+    <item>
+     <widget class="QPushButton" name="pfxPathPushButton">
+      <property name="text">
+       <string>选择Plugin默认路径</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Shadowsocks subscription usually specifies plugins like `obfs-local`. In standalone ss client they should be put in the same directory with the client executable, however, in this plugin where those plugins should go is unclear and causing a lot of confusion. While there is a per-connection option to set plugin path, in a subscription doing so is extremely tedious.

This patch add a plugin-wise option that will prepend itself to `plugin` when the per-connection `plugin` is not an absolute path. The implementation may be a little junky but it works on my machine(TM).

Fixes #4 #5.